### PR TITLE
CI: Run ubuntu-20.04 in container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,8 @@ jobs:
     strategy:
       matrix:
         target: [linux-x86_64]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container: ubuntu-20.04
     permissions:
         contents: write
     steps:


### PR DESCRIPTION
To workaround github installing a bunch of stuff on the default images, and also their state not being stable (ubuntu images change regularly)